### PR TITLE
fix: [PAGOPA-2682] Opening port 8080 for `HTTP-Trigger`ed function

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-to-event-hub
 description: Microservice fdr to event hub
 type: application
-version: 0.47.0
-appVersion: 0.0.4-2-PAGOPA-2682
+version: 0.48.0
+appVersion: 0.0.4-3-PAGOPA-2682
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-to-event-hub
 description: Microservice fdr to event hub
 type: application
-version: 0.45.0
-appVersion: 0.0.4
+version: 0.46.0
+appVersion: 0.0.4-1-PAGOPA-2682
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "0.0.4"
+    tag: "0.0.4-1-PAGOPA-2682"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:
@@ -62,7 +62,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: { }
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -114,7 +114,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: { }
+  nodeSelector: {}
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -54,7 +54,7 @@ microservice-chart:
   ingress:
     create: true
     host: "weudev.fdr.internal.dev.platform.pagopa.it"
-    path: /pagopa-fdr-to-event-hub-service(/|$)(.*)
+    path: /pagopa-fdr-to-event-hub-service/(.*)
     servicePort: 8080
   serviceAccount:
     name: "fdr-workload-identity"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -45,10 +45,12 @@ microservice-chart:
         path: /metrics
   ports:
     - 12345 #jmx-exporter
+    - 80
     - 8080
   service:
     type: ClusterIP
     ports:
+      - 80
       - 8080
       - 12345 #jmx-exporter
   ingress:
@@ -60,7 +62,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -112,7 +114,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
+  nodeSelector: { }
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -45,24 +45,22 @@ microservice-chart:
         path: /metrics
   ports:
     - 12345 #jmx-exporter
-    - 80
     - 8080
   service:
     type: ClusterIP
     ports:
-      - 80
       - 8080
       - 12345 #jmx-exporter
   ingress:
     create: true
     host: "weudev.fdr.internal.dev.platform.pagopa.it"
-    path: /pagopa-fdr-to-event-hub-service/(.*)
-    servicePort: 80
+    path: /pagopa-fdr-to-event-hub-service(/|$)(.*)
+    servicePort: 8080
   serviceAccount:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -114,7 +112,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
+  nodeSelector: { }
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "0.0.4-2-PAGOPA-2682"
+    tag: "0.0.4-3-PAGOPA-2682"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "0.0.4"
+    tag: "0.0.4-1-PAGOPA-2682"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "0.0.4-2-PAGOPA-2682"
+    tag: "0.0.4-3-PAGOPA-2682"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "0.0.4"
+    tag: "0.0.4-1-PAGOPA-2682"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "0.0.4-2-PAGOPA-2682"
+    tag: "0.0.4-3-PAGOPA-2682"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>it.gov.pagopa.fdr.to.eventhub</groupId>
 	<artifactId>pagopa-fdr-to-event-hub</artifactId>
-	<version>0.0.4-2-PAGOPA-2682</version>
+	<version>0.0.4-3-PAGOPA-2682</version>
 	<packaging>jar</packaging>
 
 	<name>FDR To Event Hub</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>it.gov.pagopa.fdr.to.eventhub</groupId>
 	<artifactId>pagopa-fdr-to-event-hub</artifactId>
-	<version>0.0.4</version>
+	<version>0.0.4-1-PAGOPA-2682</version>
 	<packaging>jar</packaging>
 
 	<name>FDR To Event Hub</name>


### PR DESCRIPTION
This PR contains a fix on exposed ports, made in order to permit the exposition of HTTP-Trigger function for external uses. Currently, the main scope of this PR is to open the 8080 port for `/info` endpoint in order to use it for pagoPA Status Page.

#### List of Changes
 - Refactoring ports in order to expose HTTP triggers out of AKS network

#### Motivation and Context
This change permits to add monitoring on this app for pagoPA Status Page

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
