### PR TITLE
fix(ENV): Add `hostid` for Storage Queue name definition

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-to-event-hub
 description: Microservice fdr to event hub
 type: application
-version: 0.50.0
-appVersion: 1.0.0
+version: 0.51.0
+appVersion: 1.0.0-1-fix-fn-state
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-to-event-hub
 description: Microservice fdr to event hub
 type: application
-version: 0.52.0
-appVersion: 1.0.0-2-fix-fn-state
+version: 0.53.0
+appVersion: 1.0.0-3-fix-fn-state
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-to-event-hub
 description: Microservice fdr to event hub
 type: application
-version: 0.51.0
-appVersion: 1.0.0-1-fix-fn-state
+version: 0.52.0
+appVersion: 1.0.0-2-fix-fn-state
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -88,6 +88,7 @@ microservice-chart:
   envConfig:
     JAVA_OPTS: "-XX:MaxHeapSize=256m -XX:MinHeapSize=64m"
     WEBSITE_SITE_NAME: "pagopafdrtoeventhub" # required to show cloud role name in application insights
+    HOSTNAME: "pagopafdrtoeventhub"
     FUNCTIONS_WORKER_RUNTIME: "java"
     BLOB_STORAGE_FDR1_CONTAINER: "fdr1-flows"
     BLOB_STORAGE_FDR3_CONTAINER: "fdr3-flows"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0"
+    tag: "1.0.0-1-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0-2-fix-fn-state"
+    tag: "1.0.0-3-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0-1-fix-fn-state"
+    tag: "1.0.0-2-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:
@@ -60,7 +60,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: { }
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -113,7 +113,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: { }
+  nodeSelector: {}
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -60,7 +60,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -88,7 +88,6 @@ microservice-chart:
   envConfig:
     JAVA_OPTS: "-XX:MaxHeapSize=256m -XX:MinHeapSize=64m"
     WEBSITE_SITE_NAME: "pagopafdrtoeventhub" # required to show cloud role name in application insights
-    HOSTNAME: "pagopafdrtoeventhub"
     FUNCTIONS_WORKER_RUNTIME: "java"
     BLOB_STORAGE_FDR1_CONTAINER: "fdr1-flows"
     BLOB_STORAGE_FDR3_CONTAINER: "fdr3-flows"
@@ -101,6 +100,7 @@ microservice-chart:
     # AzureFunctionsJobHost__logging__logLevel__Function__ProcessFDR1BlobFiles: "Debug"
     # AzureFunctionsJobHost__logging__logLevel__Function__ProcessFDR3BlobFiles: "Debug"
     FUNCTIONS_SECRETS_PATH: "/tmp/secrets"
+    AzureFunctionsWebHost__hostid: "fdr2eventhub"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"
@@ -113,7 +113,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-d-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
+  nodeSelector: { }
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0"
+    tag: "1.0.0-1-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -60,7 +60,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -100,6 +100,8 @@ microservice-chart:
     EVENT_HUB_REPORTEDIUV_NAME: "fdr-qi-reported-iuv"
     ASPNETCORE_URLS: "http://*:8080"
     FUNCTIONS_SECRETS_PATH: "/tmp/secrets"
+    # WARNING: in order to avoid the re-schedulation of blob conversion, we are using an existing queue with a casual name on PROD
+    AzureFunctionsWebHost__hostid: "pagopafdr2eventhub56ccffd76f42jg"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"
@@ -112,7 +114,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-p-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
+  nodeSelector: { }
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0-2-fix-fn-state"
+    tag: "1.0.0-3-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0-1-fix-fn-state"
+    tag: "1.0.0-2-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -60,7 +60,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -100,6 +100,7 @@ microservice-chart:
     EVENT_HUB_REPORTEDIUV_NAME: "fdr-qi-reported-iuv"
     ASPNETCORE_URLS: "http://*:8080"
     FUNCTIONS_SECRETS_PATH: "/tmp/secrets"
+    AzureFunctionsWebHost__hostid: "fdr2eventhub"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"
@@ -112,7 +113,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-u-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: {}
+  nodeSelector: { }
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0"
+    tag: "1.0.0-1-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0-2-fix-fn-state"
+    tag: "1.0.0-3-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:
@@ -60,7 +60,7 @@ microservice-chart:
     name: "fdr-workload-identity"
   azure:
     workloadIdentityClientId: <workload-identity-client-id-set-automatically-by-gha>
-  podAnnotations: { }
+  podAnnotations: {}
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -113,7 +113,7 @@ microservice-chart:
   keyvault:
     name: "pagopa-u-fdr-kv"
     tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
-  nodeSelector: { }
+  nodeSelector: {}
   tolerations:
     - key: dedicated
       operator: Equal

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-fdr-2-event-hub"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-2-event-hub
-    tag: "1.0.0-1-fix-fn-state"
+    tag: "1.0.0-2-fix-fn-state"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   # livenessProbe:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>it.gov.pagopa.fdr.to.eventhub</groupId>
 	<artifactId>pagopa-fdr-to-event-hub</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.0-1-fix-fn-state</version>
 	<packaging>jar</packaging>
 
 	<name>FDR To Event Hub</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>it.gov.pagopa.fdr.to.eventhub</groupId>
 	<artifactId>pagopa-fdr-to-event-hub</artifactId>
-	<version>1.0.0-1-fix-fn-state</version>
+	<version>1.0.0-2-fix-fn-state</version>
 	<packaging>jar</packaging>
 
 	<name>FDR To Event Hub</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>it.gov.pagopa.fdr.to.eventhub</groupId>
 	<artifactId>pagopa-fdr-to-event-hub</artifactId>
-	<version>1.0.0-2-fix-fn-state</version>
+	<version>1.0.0-3-fix-fn-state</version>
 	<packaging>jar</packaging>
 
 	<name>FDR To Event Hub</name>


### PR DESCRIPTION
This PR contains the addition of a new environment variable in order to fix an issue on Azure Function deployed on AKS cluster. At the moment, the AZ Function deployed on AKS creates a new Storage Queue (setting the same name of the related AZ Function's pod) each time a new pod starts: these queues are used to receive upsert events on `fdr1-flows` storage. This leads to process the same blob multiple times because each time a queue is created, the "consumed" Blob Storage send an event <ins>for each blob currently existing on the same storage</ins>.  
In order to avoid this problem, the field `AzureFunctionsWebHost__hostid` is set as environment variable in Helm configuration: this specific variable permits to override the name of the created storage queue, possibly using an existing one if defined.  
Note: in production environment, an unusual name is set in order to use an existing queue and avoiding the problem described before.

#### List of Changes
 - Added `AzureFunctionsWebHost__hostid` environment variable on Helm configuration

#### Motivation and Context
These changes permits to avoid the problem described.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.