### PR TITLE
fix: [PRGP-246] Removing `FreeRatio` and including `GCPause` JavaOpts

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -97,7 +97,7 @@ microservice-chart: &microservice-chart
   envConfig: &envConfig
     APP_ENVIRONMENT: "prod"
     LOG_LEVEL: "ERROR"
-    JAVA_OPTS: "-XX:+UseContainerSupport -XX:+UseG1GC -XX:MinHeapFreeRatio=30 -XX:MaxHeapFreeRatio=30 -XX:MaxHeapSize=4096m -XX:MinHeapSize=256m"
+    JAVA_OPTS: "-XX:+UseContainerSupport -XX:+UseG1GC -XX:MaxHeapSize=4096m -XX:MinHeapSize=256m -XX:MaxGCPauseMillis=200"
     WEBSITE_SITE_NAME: "pagopafdrtoeventhub" # required to show cloud role name in application insights
     FUNCTIONS_WORKER_RUNTIME: "java"
     BLOB_STORAGE_FDR1_CONTAINER: "fdr1-flows"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -97,7 +97,7 @@ microservice-chart: &microservice-chart
   envConfig: &envConfig
     APP_ENVIRONMENT: "uat"
     LOG_LEVEL: "ERROR"
-    JAVA_OPTS: "-XX:+UseContainerSupport -XX:+UseG1GC -XX:MinHeapFreeRatio=30 -XX:MaxHeapFreeRatio=30 -XX:MaxHeapSize=2304m -XX:MinHeapSize=256m"
+    JAVA_OPTS: "-XX:+UseContainerSupport -XX:+UseG1GC -XX:MaxHeapSize=2304m -XX:MinHeapSize=256m -XX:MaxGCPauseMillis=200"
     #JAVA_OPTS: "-XX:MinHeapFreeRatio=30 -XX:MaxHeapFreeRatio=30 -XX:MaxHeapSize=2304m -XX:MinHeapSize=256m -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=12345 -Dcom.sun.management.jmxremote.rmi.port=12345 -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
     WEBSITE_SITE_NAME: "pagopafdrtoeventhub" # required to show cloud role name in application insights
     FUNCTIONS_WORKER_RUNTIME: "java"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 - Removed `-XX:MinHeapFreeRatio` and `-XX:MaxHeapFreeRatio` Java Options
 - Added `-XX:MaxGCPauseMillis` Java Option

#### Motivation and Context
These changes are an attempt to reduce the number of OOM errors occurring on this service’s pod.

#### How Has This Been Tested?
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.